### PR TITLE
Add support for auto host rewriting and protocol rewriting

### DIFF
--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -42,6 +42,8 @@ module.exports.createProxyServer =
    *    localAddress : <Local interface string to bind for outgoing connections>
    *    changeOrigin: <true/false, Default: false - changes the origin of the host header to the target URL>
    *    hostRewrite: rewrites the location hostname on (301/302/307/308) redirects, Default: null.
+   *    autoRewrite: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.
+   *    protocolRewrite: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.
    *  }
    *
    *  NOTE: `options.ws` and `options.ssl` are optional.

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -47,11 +47,19 @@ var redirectRegex = /^30(1|2|7|8)$/;
   },
 
   function setRedirectHostRewrite(req, res, proxyRes, options) {
-    if (options.hostRewrite
+    if ((options.hostRewrite || options.autoRewrite || options.protocolRewrite)
         && proxyRes.headers['location']
         && redirectRegex.test(proxyRes.statusCode)) {
       var u = url.parse(proxyRes.headers['location']);
-      u.host = options.hostRewrite;
+      if (options.hostRewrite) {
+        u.host = options.hostRewrite;
+      } else if (options.autoRewrite) {
+        u.host = req.headers['host'];
+      }
+      if (options.protocolRewrite) {
+        u.protocol = options.protocolRewrite;
+      }
+
       proxyRes.headers['location'] = u.format();
     }
   },


### PR DESCRIPTION
auto host rewriting allows rewriting to work as expected in most
cases without extra cumbersome configuration

protocol rewriting allows node-http-proxy to be able to listen
over HTTPS and properly reverse-proxy to sites running over HTTP
(to avoid doing SSL twice)
